### PR TITLE
add an engagement engineering user to the relay

### DIFF
--- a/modules/mig/manifests/server/relay.pp
+++ b/modules/mig/manifests/server/relay.pp
@@ -134,6 +134,7 @@ class mig::server::relay (
                             sudo rabbitmqctl add_user agent-opsec $(grep ^agent-opsec: /etc/rabbitmq/creds|cut -d ":" -f2);
                             sudo rabbitmqctl add_user agent-moz-opsec $(grep ^agent-moz-opsec: /etc/rabbitmq/creds|cut -d ":" -f2);
                             sudo rabbitmqctl add_user agent-foundation $(grep ^agent-foundation: /etc/rabbitmq/creds|cut -d ":" -f2);
+                            sudo rabbitmqctl add_user agent-engeng $(grep ^agent-engeng: /etc/rabbitmq/creds|cut -d ":" -f2);
                             sudo rabbitmqctl add_user worker $(grep ^worker /etc/rabbitmq/creds|cut -d ":" -f2);
                             sudo rabbitmqctl add_vhost mig;
                             sudo rabbitmqctl set_permissions -p mig scheduler "^(toagents|toschedulers|toworkers|mig\.agt\..*)$" "^(toagents|toworkers|mig\.agt\.(heartbeats|results))$" "^(toagents|toschedulers|toworkers|mig\.agt\.(heartbeats|results))$";
@@ -145,6 +146,7 @@ class mig::server::relay (
                             sudo rabbitmqctl set_permissions -p mig agent-opsec "^mig\.agt\..*$" "^(toschedulers|mig\.agt\..*)$" "^(toagents|mig\.agt\..*)$";
                             sudo rabbitmqctl set_permissions -p mig agent-moz-opsec "^mig\.agt\..*$" "^(toschedulers|mig\.agt\..*)$" "^(toagents|mig\.agt\..*)$";
                             sudo rabbitmqctl set_permissions -p mig agent-foundation "^mig\.agt\..*$" "^(toschedulers|mig\.agt\..*)$" "^(toagents|mig\.agt\..*)$";
+                            sudo rabbitmqctl set_permissions -p mig agent-engeng "^mig\.agt\..*$" "^(toschedulers|mig\.agt\..*)$" "^(toagents|mig\.agt\..*)$";
                             sudo rabbitmqctl set_permissions -p mig worker "^migevent\..*$" "^migevent(|\..*)$" "^(toworkers|migevent\..*)$";',
             path        => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             subscribe   => [ File['/etc/rabbitmq/rabbitmq.config'] ],


### PR DESCRIPTION
Adds an engagement engineering user to the relay for use by engagement engineering agents
